### PR TITLE
Simplify query param

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ Encoding: UTF-8
 LazyData: true
 LinkingTo: Rcpp
 Imports: Rcpp, dplyr, yaml, stringr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1

--- a/R/gcamwrapper.R
+++ b/R/gcamwrapper.R
@@ -45,10 +45,10 @@ run_to_period <- function(gcam, period = NULL) {
 #' @param query_params (list[string] -> array(string)) User options to translate placeholder
 #' @return GCAM instance
 #' @export
-set_data <- function(gcam, data, query, query_params = NULL) {
-  if(!is.null(query_params)) {
-      query <- apply_query_params(query, query_params, FALSE)
-  }
+set_data <- function(gcam, data, query, query_params = list()) {
+  # replace any potential place holders in the query with the query params
+  query <- apply_query_params(query, query_params, FALSE)
+
   gcam$set_data(data, query)
 }
 
@@ -62,11 +62,11 @@ set_data <- function(gcam, data, query, query_params = NULL) {
 #' @export
 #' @importFrom dplyr group_by_at vars summarize_at ungroup as_tibble
 #' @importFrom magrittr %>%
-get_data <- function(gcam, query, query_params = NULL) {
+get_data <- function(gcam, query, query_params = list()) {
   units <- attr(query, 'units')
-  if(!is.null(query_params)) {
-      query <- apply_query_params(query, query_params, TRUE)
-  }
+  # replace any potential place holders in the query with the query params
+  query <- apply_query_params(query, query_params, TRUE)
+
   data <- gcam$get_data(query)
   # The data comming out of gcam is unaggregated so we will need to do that now
   # first figure out what the "value" column is, group by everything else, and summarize

--- a/gcamwrapper/main.py
+++ b/gcamwrapper/main.py
@@ -1,6 +1,7 @@
 import gcam_module
 from pandas import DataFrame, Series
 from gcamwrapper.query_library import apply_query_params
+import warnings
 
 
 class Gcam(gcam_module.gcam):
@@ -34,9 +35,9 @@ class Gcam(gcam_module.gcam):
         :param *args: User options to translate placeholder expressions which will
                       will be added to the kwargs as dict(arg: None)
         :type *args:  str
-        :param *kargs: User options to translate placeholder expressions which will
-                       get combined with *args and passed on to apply_query_params
-        :type *kargs: key = arrary(str)
+        :param **kargs: User options to translate placeholder expressions which will
+                        get combined with *args and passed on to apply_query_params
+        :type **kargs:  key = arrary(str)
 
         :returns:       DataFrame with the query results.
 
@@ -59,10 +60,16 @@ class Gcam(gcam_module.gcam):
         value_col = cols[-2] if cols[-1] == "year" else cols[-1]
         data_df = data_df.groupby(cols.drop(value_col).to_list(), as_index=False).sum()
         if units is not None:
-            data_df['meta'] = {'units': units}
+            # Attempting to attach meta data to the data frame will generate a warning:
+            # Pandas doesn't allow columns to be created via a new attribute name
+            # We are of course not trying to generate a new column so the warning
+            # is not relevant, thus an explict ignore is needed
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                data_df.meta = {'units': units}
         return data_df
 
-    def set_data(self, data_df, query, *args, *kwargs):
+    def set_data(self, data_df, query, *args, **kwargs):
         """Changes arbitrary data in a running instance of GCAM.
 
         :param data_df:     DataFrame of data to set
@@ -72,9 +79,9 @@ class Gcam(gcam_module.gcam):
         :param *args: User options to translate placeholder expressions which will
                       will be added to the kwargs as dict(arg: None)
         :type *args:  str
-        :param *kargs: User options to translate placeholder expressions which will
-                       get combined with *args and passed on to apply_query_params
-        :type *kargs: key = arrary(str)
+        :param **kargs: User options to translate placeholder expressions which will
+                        get combined with *args and passed on to apply_query_params
+        :type **kargs:  key = arrary(str)
 
         """
 

--- a/man/apply_query_params.Rd
+++ b/man/apply_query_params.Rd
@@ -24,6 +24,6 @@ where we match those keys to `arg_type`.  If `arg_type` is "name" then \link{par
 will be used to process the value of query_params[[arg_tag]] and if "year" then
 \link{parse_int_query_param} is used.
 Note symantics are slightly different if is_get_data is true as described in parse_.*_query_params.
-For any arg_tag which has no entry in query_params it will be replaced with nothing
-which tells GCAM Fusion to match any but do not read/write to the DataFrame for that container.
+For any arg_tag which has no entry in query_params it will be given the results of passing `NULL`
+to parse_int/str_query_param.
 }

--- a/man/create_and_initialize.Rd
+++ b/man/create_and_initialize.Rd
@@ -4,8 +4,7 @@
 \alias{create_and_initialize}
 \title{Create GCAM instance}
 \usage{
-create_and_initialize(configuration = "configuration.xml",
-  workdir = ".")
+create_and_initialize(configuration = "configuration.xml", workdir = ".")
 }
 \arguments{
 \item{configuration}{(string) The configuration XML to use.}

--- a/man/get_data.Rd
+++ b/man/get_data.Rd
@@ -4,7 +4,7 @@
 \alias{get_data}
 \title{Get some arbitrary data out of GCAM}
 \usage{
-get_data(gcam, query, query_params = NULL)
+get_data(gcam, query, query_params = list())
 }
 \arguments{
 \item{gcam}{(gcam) An initialized GCAM instance}

--- a/man/parse_int_query_param.Rd
+++ b/man/parse_int_query_param.Rd
@@ -17,11 +17,11 @@ A GCAM Fusion filter string representing the parameters given.
 }
 \description{
 The currently supported operators are:
-`+`: Indicates to read/write to a DataFrame.  Note if `is_get_data` this is always
-implied to be set.
-`*`: which always matches and so no additional operands are necessary (note if
-param_operands is empty this operator is assumed)
+`+`, `-`: Indicates to read/write to a DataFrame if `+` or not to read/write if `-`
+`*`: which always matches and so no additional operands are necessary
 The standard comparison operators: `=`, `<`, `<=`, `>`, `>=`. Note if `is_get_data` is true
-or the `+` is not set an additional argument must be supplied which is the integer (or a
+or the `-` is set an additional argument must be supplied which is the integer (or a
 string that can be converted to integer) to be used as the RHS operand in the comparison.
+Finally if param_operands is NULL or empty then if `is_get_data` then c('+', '*') is assumed
+otherwise c('+', '=').
 }

--- a/man/parse_str_query_param.Rd
+++ b/man/parse_str_query_param.Rd
@@ -17,11 +17,11 @@ A GCAM Fusion filter string representing the parameters given.
 }
 \description{
 The currently supported operators are:
-`+`: Indicates to read/write to a DataFrame.  Note if `is_get_data` this is always
-implied to be set.
-`*`: which always matches and so no additional operands are necessary (note if
-param_operands is empty this operator is assumed)
+`+`, `-`: Indicates to read/write to a DataFrame if `+` or not to read/write if `-`
+`*`: which always matches and so no additional operands are necessary
 The operators: `=`, `=~` (regular expression matching). Note if `is_get_data` is true
-or the `+` is not set an additional argument must be supplied which is the string to
+or the `-` is set an additional argument must be supplied which is the string to
 be used as the RHS operand in the comparison.
+Finally if param_operands is NULL or empty then if `is_get_data` then c('+', '*') is assumed
+otherwise c('+', '=').
 }

--- a/man/set_data.Rd
+++ b/man/set_data.Rd
@@ -4,7 +4,7 @@
 \alias{set_data}
 \title{Set some aribtrary data into GCAM}
 \usage{
-set_data(gcam, data, query, query_params = NULL)
+set_data(gcam, data, query, query_params = list())
 }
 \arguments{
 \item{gcam}{(gcam) An initialized GCAM instance}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pandas
+pyyaml


### PR DESCRIPTION
As discussed in #10.  The query placeholder syntax is a bit verbose.  In particular we could do a lot by making better defaults which wouldn't require users to set any place holders.  For instance the defaults for `get_data` should be to record the value and match any (`['+', '*']`):
```
>>> query = gw.get_query("socioeconomic", "labor_productivity")
>>> g.get_data(query)
             region  year  laborproductivity
0    Africa_Eastern  1975            0.00154
1    Africa_Eastern  1990            0.00154
2    Africa_Eastern  2005            0.01216
3    Africa_Eastern  2010            0.03926
4    Africa_Eastern  2015            0.02085
..              ...   ...                ...
699             USA  2080            0.00584
700             USA  2085            0.00577
701             USA  2090            0.00572
702             USA  2095            0.00573
703             USA  2100            0.00577

[704 rows x 3 columns]
```

The other thing to note is we switch to using `**kwargs` instead of a dict to reduce syntax even further:
```
>>> lbr = g.get_data(query, region=["=", "USA"], year=["<=", 2005])
>>> lbr
  region  year  laborproductivity
0    USA  1975            0.02482
1    USA  1990            0.02482
2    USA  2005            0.02076
```

The main reason we didn't implement this as the default prior was because the old default behavior was in essence the only way to ask get/set data to drop / ignore a column in the DataFrame.  Instead we now add the `-` processing instruction (the opposite of `+`) which tells gcamwrapper explicitly to do that:
```
>> g.get_data(query, region=["-", "=", "USA"], year=["<=", 2005])
   year  laborproductivity
0  1975            0.02482
1  1990            0.02482
2  2005            0.02076
```

The defaults for `set_data` are similarly geared towards smart defaults.  In this case to match all columns given using equality (`['+', '=']`):
```
>>> lbr['laborproductivity'] = 0.02
>>> g.set_data(lbr, query)
>>> g.get_data(query, region=["-", "=", "USA"], year=["<=", 2020])
   year  laborproductivity
0  1975            0.02000
1  1990            0.02000
2  2005            0.02000
3  2010           -0.00171
4  2015            0.01423
5  2020            0.01361
```