### PR TITLE
Documenation update

### DIFF
--- a/R/gcamwrapper.R
+++ b/R/gcamwrapper.R
@@ -125,7 +125,7 @@ get_data <- function(gcam, query, query_params = list()) {
 
 #' Get the last run GCAM model period
 #' @param gcam (gcam) An initialized GCAM instance
-#' @return (integer) The last period used in `run_to_period` whether it succeeded or failed
+#' @return (integer) The last period used in `run_period` whether it succeeded or failed
 #' @export
 get_current_period <- function(gcam) {
     gcam$get_current_period()
@@ -133,7 +133,7 @@ get_current_period <- function(gcam) {
 
 #' Get the last run GCAM model year
 #' @param gcam (gcam) An initialized GCAM instance
-#' @return (integer) The last period used in `run_to_period` whether it
+#' @return (integer) The last period used in `run_period` whether it
 #" succeeded or failed but converted to year
 #' @export
 get_current_year <- function(gcam) {

--- a/R/gcamwrapper.R
+++ b/R/gcamwrapper.R
@@ -125,7 +125,7 @@ get_data <- function(gcam, query, query_params = list()) {
 
 #' Get the last run GCAM model period
 #' @param gcam (gcam) An initialized GCAM instance
-#' @return (integer) The last period used in `run_to_period` wheter it succeeded or failed
+#' @return (integer) The last period used in `run_to_period` whether it succeeded or failed
 #' @export
 get_current_period <- function(gcam) {
     gcam$get_current_period()
@@ -133,7 +133,7 @@ get_current_period <- function(gcam) {
 
 #' Get the last run GCAM model year
 #' @param gcam (gcam) An initialized GCAM instance
-#' @return (integer) The last period used in `run_to_period` wheter it
+#' @return (integer) The last period used in `run_to_period` whether it
 #" succeeded or failed but converted to year
 #' @export
 get_current_year <- function(gcam) {

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ library(ggplot2)
 # appropriate working directory
 g <- create_and_initialize("configuration_ref.xml", "/Users/pralitp/model/gcam-core-git/exe")
 # Run the model up to period 5, the year 2020
-run_to_period(g, 5L)
+run_period(g, 5L)
 
 # Do a simple experiment: see how CO2 emissions change after arbitrarily changing
 # the GDP
@@ -213,7 +213,7 @@ double_check <- get_data(g, labor_prod_query, list("region", "year" = c("=", 202
 
 # we have only set the parameters at this point, to see how it effects
 # results we must re-run period 5
-run_to_period(g, 5L)
+run_period(g, 5L)
 
 # Get the CO2 emissions again and see how they have changed
 co2_change <- get_data(g, co2_query, query_params)
@@ -290,7 +290,7 @@ import gcamwrapper
 # appropriate working directory
 g = gcamwrapper.Gcam("configuration_ref.xml", "C:/GCAM/gcam-core/exe")
 # Run the model up to period 5, the year 2020
-g.run_to_period(5)
+g.run_period(5)
 
 # Do a simple experiment: see how CO2 emissions change after arbitrarily changing
 # the GDP
@@ -363,7 +363,7 @@ double_check = g.get_data(labor_prod_query, "region", "year"=["=", 2020])
 
 # we have only set the parameters at this point, to see how it effects
 # results we must re-run period 5
-g.run_to_period(5)
+g.run_period(5)
 
 # Get the CO2 emissions again and see how they have changed
 co2_change = g.get_data(co2_query, **query_params)

--- a/gcamwrapper/main.py
+++ b/gcamwrapper/main.py
@@ -176,7 +176,7 @@ class Gcam(gcam_module.gcam):
     def get_current_period(self):
         """Get the last run GCAM model period
 
-        :returns: The last period used in `run_to_period` wheter it succeeded or failed
+        :returns: The last period used in `run_to_period` whether it succeeded or failed
         """
 
         return super(Gcam, self).get_current_period()
@@ -184,7 +184,7 @@ class Gcam(gcam_module.gcam):
     def get_current_year(self):
         """Get the last run GCAM model year
 
-        :returns: The last period used in `run_to_period` wheter it succeeded or failed but converted to year
+        :returns: The last period used in `run_to_period` whether it succeeded or failed but converted to year
         """
 
         return self.convert_period_to_year(self.get_current_period())

--- a/gcamwrapper/main.py
+++ b/gcamwrapper/main.py
@@ -176,7 +176,7 @@ class Gcam(gcam_module.gcam):
     def get_current_period(self):
         """Get the last run GCAM model period
 
-        :returns: The last period used in `run_to_period` whether it succeeded or failed
+        :returns: The last period used in `run_period` whether it succeeded or failed
         """
 
         return super(Gcam, self).get_current_period()
@@ -184,7 +184,7 @@ class Gcam(gcam_module.gcam):
     def get_current_year(self):
         """Get the last run GCAM model year
 
-        :returns: The last period used in `run_to_period` whether it succeeded or failed but converted to year
+        :returns: The last period used in `run_period` whether it succeeded or failed but converted to year
         """
 
         return self.convert_period_to_year(self.get_current_period())

--- a/man/get_current_period.Rd
+++ b/man/get_current_period.Rd
@@ -10,7 +10,7 @@ get_current_period(gcam)
 \item{gcam}{(gcam) An initialized GCAM instance}
 }
 \value{
-(integer) The last period used in `run_to_period` wheter it succeeded or failed
+(integer) The last period used in `run_to_period` whether it succeeded or failed
 }
 \description{
 Get the last run GCAM model period

--- a/man/get_current_period.Rd
+++ b/man/get_current_period.Rd
@@ -10,7 +10,7 @@ get_current_period(gcam)
 \item{gcam}{(gcam) An initialized GCAM instance}
 }
 \value{
-(integer) The last period used in `run_to_period` whether it succeeded or failed
+(integer) The last period used in `run_period` whether it succeeded or failed
 }
 \description{
 Get the last run GCAM model period

--- a/man/get_current_year.Rd
+++ b/man/get_current_year.Rd
@@ -10,7 +10,7 @@ get_current_year(gcam)
 \item{gcam}{(gcam) An initialized GCAM instance}
 }
 \value{
-(integer) The last period used in `run_to_period` wheter it
+(integer) The last period used in `run_to_period` whether it
 }
 \description{
 Get the last run GCAM model year

--- a/man/get_current_year.Rd
+++ b/man/get_current_year.Rd
@@ -10,7 +10,7 @@ get_current_year(gcam)
 \item{gcam}{(gcam) An initialized GCAM instance}
 }
 \value{
-(integer) The last period used in `run_to_period` whether it
+(integer) The last period used in `run_period` whether it
 }
 \description{
 Get the last run GCAM model year


### PR DESCRIPTION
As I was working through the R gcamwrapper example included in the README, I was running into issues with `run_to_period`. It looks like that function is no longer exported as part of the package, changing the call to `run_period` seemed to work though. This PR updates the README example & some function documentation that used the deprecated `run_to_period` call.  

